### PR TITLE
AIS: added missed function ship_name to message 19

### DIFF
--- a/src/marnav/ais/message_19.cpp
+++ b/src/marnav/ais/message_19.cpp
@@ -105,10 +105,10 @@ void message_19::set_latitude(const utils::optional<geo::latitude> & t)
 
 void message_19::set_shipname(const std::string & t)
 {
-        if (t.size() > 20) {
-	        shipname = t.substr(0, 20);
+	if (t.size() > 20) {
+		shipname = t.substr(0, 20);
 	} else {
-	        shipname = t;
+		shipname = t;
 	}
 }
 }

--- a/src/marnav/ais/message_19.cpp
+++ b/src/marnav/ais/message_19.cpp
@@ -102,5 +102,14 @@ void message_19::set_latitude(const utils::optional<geo::latitude> & t)
 		? to_latitude_minutes(t.value(), latitude_minutes.count, angle_scale::I4)
 		: latitude_not_available;
 }
+
+void message_19::set_shipname(const std::string & t)
+{
+        if (t.size() > 20) {
+	        shipname = t.substr(0, 20);
+	} else {
+	        shipname = t;
+	}
+}
 }
 }


### PR DESCRIPTION
Hi,
I've found that function ship_name() was missed in message19 (AIS).
