### PR TITLE
Fixed build issues caused by deprecated qt5_add_modules command.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.11)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Compiler:
 - Clang 6.0
 
 Tools needed to build the library:
-- cmake 3.2 or newer
+- cmake 3.11 or newer
 
 Tools needed to develop the library:
 - git

--- a/examples/library/CMakeLists.txt
+++ b/examples/library/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.11)
 project(foobar LANGUAGES CXX VERSION 0.0.0)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/examples/qtnmeadiag/CMakeLists.txt
+++ b/examples/qtnmeadiag/CMakeLists.txt
@@ -10,10 +10,6 @@ if(${Qt5Core_FOUND})
 	message(STATUS "  ${Qt5Widgets_LIBRARIES}")
 	message(STATUS "  ${Qt5SerialPort_LIBRARIES}")
 
-	include_directories(${Qt5Core_INCLUDE_DIRS})
-	include_directories(${Qt5Widgets_INCLUDE_DIRS})
-	include_directories(${Qt5SerialPort_INCLUDE_DIRS})
-
 	set(CMAKE_AUTOMOC ON)
 
 	add_executable(qtnmeadiag
@@ -21,14 +17,7 @@ if(${Qt5Core_FOUND})
 		main.cpp
 		)
 
-	target_link_libraries(qtnmeadiag
-		${Qt5SerialPort_LIBRARIES}
-		${Qt5Widgets_LIBRARIES}
-		${Qt5Core_LIBRARIES}
-		marnav
-		)
-
-	qt5_use_modules(qtnmeadiag Core Widgets SerialPort)
+	target_link_libraries(qtnmeadiag Qt5::SerialPort Qt5::Widgets Qt5::Core marnav)
 
 else()
 	message(STATUS "Qt5 not found")

--- a/examples/subproject/CMakeLists.txt
+++ b/examples/subproject/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.11)
 project(marnav-demo VERSION 0.0.0 LANGUAGES CXX C)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.11)
 
 option(ENABLE_STATIC "Enable static library" ON)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.11)
+
 add_executable(testrunner)
 
 target_sources(testrunner


### PR DESCRIPTION
* Fixed build issues caused by deprecated qt5_add_modules command. 
* Specified a minimum Cmake version in a CMakeLists.txt file which contained CMake 3.11 features. (Compare first paragraph text of https://cmake.org/cmake/help/v3.11/command/add_executable.html between Cmake 3.11 and previous versions.)