### PR TITLE
Update io_double_strtodl.cpp

### DIFF
--- a/src/marnav/nmea/io_double_strtodl.cpp
+++ b/src/marnav/nmea/io_double_strtodl.cpp
@@ -13,7 +13,7 @@ namespace marnav
 {
 namespace nmea
 {
-void read(const std::string & s, double & value, data_format fmt)
+inline void read(const std::string & s, double & value, data_format fmt)
 {
 	utils::unused(fmt);
 	if (s.empty())


### PR DESCRIPTION
fix android multiple definition of `marnav::nmea::read(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&, double&, marnav::nmea::data_format)