### PR TITLE
Add <cstdint> include where required to build with GCC 13.1

### DIFF
--- a/examples/bitset_iterate.cpp
+++ b/examples/bitset_iterate.cpp
@@ -1,4 +1,5 @@
 #include <marnav/utils/bitset.hpp>
+#include <cstdint>
 #include <iostream>
 
 int main(int, char **)

--- a/include/marnav/ais/ais.hpp
+++ b/include/marnav/ais/ais.hpp
@@ -2,6 +2,7 @@
 #define MARNAV_AIS_DECODE_HPP
 
 #include <marnav/ais/message.hpp>
+#include <cstdint>
 #include <stdexcept>
 #include <vector>
 

--- a/include/marnav/ais/binary_data.hpp
+++ b/include/marnav/ais/binary_data.hpp
@@ -2,6 +2,7 @@
 #define MARNAV_AIS_BINARY_DATA_HPP
 
 #include <marnav/utils/bitset.hpp>
+#include <cstdint>
 #include <string>
 
 namespace marnav::ais

--- a/include/marnav/nmea/checksum.hpp
+++ b/include/marnav/nmea/checksum.hpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <stdexcept>
+#include <cstdint>
 #include <string>
 
 namespace marnav::nmea

--- a/include/marnav/nmea/date.hpp
+++ b/include/marnav/nmea/date.hpp
@@ -1,6 +1,7 @@
 #ifndef MARNAV_NMEA_DATE_HPP
 #define MARNAV_NMEA_DATE_HPP
 
+#include <cstdint>
 #include <string>
 
 namespace marnav::nmea

--- a/include/marnav/utils/mmsi_country.hpp
+++ b/include/marnav/utils/mmsi_country.hpp
@@ -1,6 +1,7 @@
 #ifndef MARNAV_UTILS_MMSI_COUNTRY_HPP
 #define MARNAV_UTILS_MMSI_COUNTRY_HPP
 
+#include <cstdint>
 #include <string>
 
 namespace marnav::utils

--- a/src/nmeatool/nmeatool.cpp
+++ b/src/nmeatool/nmeatool.cpp
@@ -168,6 +168,7 @@
 #include <fmt/format.h>
 #include <fmt/printf.h>
 
+#include <cstdint>
 #include <fstream>
 #include <sstream>
 #include <iostream>


### PR DESCRIPTION
With latest GCC 13 explicit inclusion of `<cstdint>` is required for integer types to be available